### PR TITLE
Strip newlines from generated HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Strip newlines from generated HTML to prevent unnecessary spaces to be added. [#9](https://github.com/erikw/jekyll-glossary_tooltip/issues/9)
 
 ## [1.5.0] - 2022-09-08
 ### Added

--- a/lib/jekyll-glossary_tooltip/tag.rb
+++ b/lib/jekyll-glossary_tooltip/tag.rb
@@ -15,12 +15,13 @@ module Jekyll
       def render(context)
         entry = lookup_entry(context.registers[:site], @opts[:term_query])
         @opts[:display] ||= @opts[:term_query]
-        <<~HTML
+        html = <<~HTML
           <span class="jekyll-glossary">
              #{@opts[:display]}
              <span class="jekyll-glossary-tooltip">#{entry["definition"]}#{render_tooltip_url(entry, context)}</span>
           </span>
         HTML
+        html.gsub("\n", "")
       end
 
       private

--- a/spec/fixtures/normal/page7.md
+++ b/spec/fixtures/normal/page7.md
@@ -1,0 +1,8 @@
+---
+title: "Fixture page 6"
+layout: default
+---
+
+# Fixture
+
+When a term is followed by a comma {% glossary term_without_url %}, no space before comma..

--- a/spec/jekyll-glossary_tooltip/tag_spec.rb
+++ b/spec/jekyll-glossary_tooltip/tag_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Jekyll::GlossaryTooltip::Tag do
     let(:page4) { File.read(dest_dir("page4.html")) }
     let(:page5) { File.read(dest_dir("page5.html")) }
     let(:page6) { File.read(dest_dir("page6.html")) }
+    let(:page7) { File.read(dest_dir("page7.html")) }
 
     it "renders a glossary tag with a URL" do
       expect_tag_match(page1, "term_with_url")
@@ -45,6 +46,15 @@ RSpec.describe Jekyll::GlossaryTooltip::Tag do
 
     it "renders a glossary tag with URL rendered from embedded liquid tags" do
       expect_tag_match(page6, "term_with_url_embedded_liquid", href: "/page2.html")
+    end
+
+    it "renders no unnecessary space after tooltip" do
+      # expect_tag_match(page7, "term_with_url", href: "/page2.html")
+      term_name = "term_without_url"
+      regex = %r{#{R1}#{term_name}#{R2}#{term_name} definition}
+      regex = Regexp.new(regex.source + %r{#{R5}, no space before comma.}.source)
+
+      expect(page7).to match(regex)
     end
   end
 


### PR DESCRIPTION
This prevents a space to be added e.g. before a comma directly after the term,
which looks bad.

Fixes #9
