### PR TITLE
Add hidden parenthesis that will be visible for `post.excerpt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [BREAKING] Hidden with CSS parenthesis around term definition. These parenthesis will be revealed when jekyll produces a post.except as typically HTML and CSS stripped => the plain text rendering of the glossary tag will be "<term-name> (term-description> <term-url>)". [#7](https://github.com/erikw/jekyll-glossary_tooltip/issues/7)
+    - To upgrade to new version, you need to update the CSS by re-copy the full contexts of [jekyll-glossary_tooltip.css](lib/jekyll-glossary_tooltip/jekyll-glossary_tooltip.css) to your side. The new CSS class `.jekyll-glossary-tooltip-hidden` is added and needed to hide parenthesis in the tooltip.
+
 ## [1.5.1] - 2025-03-10
 ### Fixed
 - Strip newlines from generated HTML to prevent unnecessary spaces to be added. [#9](https://github.com/erikw/jekyll-glossary_tooltip/issues/9)
 
 ## [1.5.0] - 2022-09-08
 ### Added
-- Support for embedded liqid tags in the url field. ([#3](https://github.com/erikw/jekyll-glossary_tooltip/issues/3])
+- Support for embedded liquid tags in the url field. ([#3](https://github.com/erikw/jekyll-glossary_tooltip/issues/3])
 
 ## [1.4.0] - 2021-08-18
 ### Changed

--- a/lib/jekyll-glossary_tooltip/jekyll-glossary_tooltip.css
+++ b/lib/jekyll-glossary_tooltip/jekyll-glossary_tooltip.css
@@ -57,3 +57,12 @@
 .jekyll-glossary:hover .jekyll-glossary-tooltip {
   opacity: 1;
 }
+
+/* HACK: hide surrounding parenthesis on definition. When Jekyll renders
+ * post.excerpt, all HTML and CSS is stripped. The effect is that the extra
+ * parenthesis that are added are hidden in the normal blog post with hoover, but
+ * hidden in the post.except when html and css is stripped. Ref:
+ * https://github.com/erikw/jekyll-glossary_tooltip/issues/7#issuecomment-2711471867 */
+ .jekyll-glossary-tooltip-hidden {
+    display: none;
+  }

--- a/lib/jekyll-glossary_tooltip/tag.rb
+++ b/lib/jekyll-glossary_tooltip/tag.rb
@@ -17,8 +17,10 @@ module Jekyll
         @opts[:display] ||= @opts[:term_query]
         html = <<~HTML
           <span class="jekyll-glossary">
-             #{@opts[:display]}
-             <span class="jekyll-glossary-tooltip">#{entry["definition"]}#{render_tooltip_url(entry, context)}</span>
+            #{@opts[:display]}
+            <span class="jekyll-glossary-tooltip">
+              <span class="jekyll-glossary-tooltip-hidden">(</span>#{entry["definition"]}#{render_tooltip_url(entry, context)}<span class="jekyll-glossary-tooltip-hidden">)</span>
+            </span>
           </span>
         HTML
         html.gsub("\n", "")

--- a/spec/jekyll-glossary_tooltip/tag_spec.rb
+++ b/spec/jekyll-glossary_tooltip/tag_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe Jekyll::GlossaryTooltip::Tag do
     it "renders no unnecessary space after tooltip" do
       # expect_tag_match(page7, "term_with_url", href: "/page2.html")
       term_name = "term_without_url"
-      regex = %r{#{R1}#{term_name}#{R2}#{term_name} definition}
-      regex = Regexp.new(regex.source + %r{#{R5}, no space before comma.}.source)
+      regex = %r{#{R1}#{term_name}#{R2}#{R_PAR_OPEN}#{term_name} definition}
+      regex = Regexp.new(regex.source + %r{#{R_PAR_CLOSE}#{R5}, no space before comma.}.source)
 
       expect(page7).to match(regex)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,8 @@ DEST_DIR   = File.expand_path("dest", __dir__)
 # Tag matching regex parts.
 R1 = %r{<span class="jekyll-glossary">\s*}
 R2 = %r{\s*<span class="jekyll-glossary-tooltip">\s*}
+R_PAR_OPEN = %r{\s*<span class="jekyll-glossary-tooltip-hidden">\(</span>\s*}
+R_PAR_CLOSE = %r{\s*<span class="jekyll-glossary-tooltip-hidden">\)</span>\s*}
 R3 = %r{\s*<br(\s/)?><a class="jekyll-glossary-source-link" href="}
 R4 = %r{" target="_blank"></a>\s*}
 R5 = %r{</span>\s*</span>}
@@ -64,12 +66,12 @@ RSpec.configure do |config|
   def expect_tag_match(content, term_name, url: true, term_display: nil, href: nil)
     term_display ||= term_name
 
-    regex = %r{#{R1}#{term_display}#{R2}#{term_name} definition}
+    regex = %r{#{R1}#{term_display}#{R2}#{R_PAR_OPEN}#{term_name} definition}
     if url
       href ||= "#{term_name} url"
       regex = Regexp.new(regex.source + %r{#{R3}#{href}#{R4}}.source)
     end
-    regex = Regexp.new(regex.source + %r{#{R5}}.source)
+    regex = Regexp.new(regex.source + %r{#{R_PAR_CLOSE}#{R5}}.source)
 
     expect(content).to match(regex)
   end


### PR DESCRIPTION
The parenthesis around the term definition is hidden with CSS in the normal
case. When Jekyll renders a post.excerpt, HTML and CSS is stripped and the
parenthesis are revealed!

Fixes #7


# PR Checklist
- [ ] Create new major release.