### PR TITLE
Add Unicode support

### DIFF
--- a/lib/jekyll-glossary_tooltip/options_parser.rb
+++ b/lib/jekyll-glossary_tooltip/options_parser.rb
@@ -7,7 +7,7 @@ module Jekyll
     # Stripped down & modified version of
     # https://github.com/ayastreb/jekyll-maps/blob/master/lib/jekyll-maps/options_parser.rb
     class OptionsParser
-      ARGS_PATTERN = %r{\s*(\w[-_\w]*):\s*(\w[^,\n\r]*)}
+      ARGS_PATTERN = %r{\s*([\p{L}_][-\p{L}_]*):\s*([\p{L}_][^,\n\r]*)}
       ARGS_ALLOWED = %w[
         display
       ].freeze

--- a/spec/fixtures/normal/page8.md
+++ b/spec/fixtures/normal/page8.md
@@ -1,0 +1,6 @@
+---
+title: "Fixture page 8"
+layout: default
+---
+
+{% glossary term_with_url, display: José Álvarez %}

--- a/spec/jekyll-glossary_tooltip/tag_spec.rb
+++ b/spec/jekyll-glossary_tooltip/tag_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Jekyll::GlossaryTooltip::Tag do
     let(:page5) { File.read(dest_dir("page5.html")) }
     let(:page6) { File.read(dest_dir("page6.html")) }
     let(:page7) { File.read(dest_dir("page7.html")) }
+    let(:page8) { File.read(dest_dir("page8.html")) }
 
     it "renders a glossary tag with a URL" do
       expect_tag_match(page1, "term_with_url")
@@ -55,6 +56,11 @@ RSpec.describe Jekyll::GlossaryTooltip::Tag do
       regex = Regexp.new(regex.source + %r{#{R_PAR_CLOSE}#{R5}, no space before comma.}.source)
 
       expect(page7).to match(regex)
+    end
+
+    it "renders a glossary tag with Unicode characters in display" do
+      # verify that the parser accepts ‘display’ with accents/Unicode
+      expect_tag_match(page8, "term_with_url", term_display: "José Álvarez")
     end
   end
 


### PR DESCRIPTION
**Issue:** Spanish words are not accepted because accents or special characters (e.g., “ñ”) cannot be included.

This PR seeks to expand the range of words accepted in the glossary.